### PR TITLE
add Github CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ctreatma @displague


### PR DESCRIPTION
Defines maintainers @ctreatma and @displague as reviewers.

I would have referenced @linode/3pt but you can't cross organizations here.

Per #3 