### PR TITLE
Dependencies: Update Plugin Framework to v0.9.2

### DIFF
--- a/provider/go.mod
+++ b/provider/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/linode/terraform-provider-linode v0.0.0
-	github.com/pulumi/pulumi-terraform-bridge/pf v0.9.1
+	github.com/pulumi/pulumi-terraform-bridge/pf v0.9.2
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.47.2
 	github.com/pulumi/pulumi/sdk/v3 v3.67.1
 )
@@ -202,7 +202,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/posener/complete v1.2.3 // indirect
 	github.com/pulumi/pulumi-java/pkg v0.9.2 // indirect
-	github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.3 // indirect
+	github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.4 // indirect
 	github.com/pulumi/pulumi-yaml v1.1.1 // indirect
 	github.com/pulumi/pulumi/pkg/v3 v3.67.1 // indirect
 	github.com/pulumi/schema-tools v0.1.2 // indirect

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -1708,13 +1708,13 @@ github.com/prometheus/prometheus v0.37.0/go.mod h1:egARUgz+K93zwqsVIAneFlLZefyGO
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/pulumi/pulumi-java/pkg v0.9.2 h1:fpBwf1NHf3j5YuigOWsXPvJCAFivEp1D6aOlYIrSbr0=
 github.com/pulumi/pulumi-java/pkg v0.9.2/go.mod h1:+5V4jggi3063hksi28zYvLm42UWVg3VqpR6qGZraIdM=
-github.com/pulumi/pulumi-terraform-bridge/pf v0.9.1 h1:Y/RTRnPelN2FFZUkYqVX8BvNpKp0fJUBK2u5H7cBzr0=
-github.com/pulumi/pulumi-terraform-bridge/pf v0.9.1/go.mod h1:gSFHOCAEiConvcxLQp5BMHOzdkwDhx0EX0gnO6lwvRQ=
+github.com/pulumi/pulumi-terraform-bridge/pf v0.9.2 h1:QAI5ARDZONWG97+yZ0Vf53NrhWyNHBFISbq4HFFubqQ=
+github.com/pulumi/pulumi-terraform-bridge/pf v0.9.2/go.mod h1:rUC7XaCNENbPNHCiIByDpgrYY11NzjnxwE/16+eh4sw=
 github.com/pulumi/pulumi-terraform-bridge/testing v0.0.1 h1:SCg1gjfY9N4yn8U8peIUYATifjoDABkyR7H9lmefsfc=
 github.com/pulumi/pulumi-terraform-bridge/v3 v3.47.2 h1:uNrHr+VQJ5e8GzLt8c3iBG32KHjG3Z2YBvtTncsy39U=
 github.com/pulumi/pulumi-terraform-bridge/v3 v3.47.2/go.mod h1:bXuzPzwY73LZH5+EgdSlHTV8ed09p51ztpca2G13fLI=
-github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.3 h1:1SmRVwRnrplcdBVVgoKYL8xqW8dCeiQPSwpGkx4ga6U=
-github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.3/go.mod h1:n0TS1WsPjOfto6hyDZbXfNZQuLli2X9iDWt2nzmQJsg=
+github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.4 h1:rIzMmtcVpPX8ynaz6/nW5AHNY63DiNfCohqmxWvMpM4=
+github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.4/go.mod h1:Kt8RIZWa/N8rW3+0g6NrqCBmF3o+HuIhFaZpssEkG6w=
 github.com/pulumi/pulumi-yaml v1.1.1 h1:8pyBNIU8+ym0wYpjhsCqN+cutygfK1XbhY2YEeNfyXY=
 github.com/pulumi/pulumi-yaml v1.1.1/go.mod h1:GhpdS6rFpwqvUtKdA+fQy8P28iNvncng39IXh5q68vE=
 github.com/pulumi/pulumi/pkg/v3 v3.67.1 h1:8KdVLHoSFu9rP031Pg4iOjtHD93UurmTJn/103B2Ayk=


### PR DESCRIPTION
Apply changes from https://github.com/pulumi/pulumi-terraform-bridge/pull/1142.
