### PR TITLE
Upgrade terraform-provider-linode to v2.7.1

### DIFF
--- a/provider/go.mod
+++ b/provider/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/linode/terraform-provider-linode v0.0.0
 	github.com/pulumi/pulumi-terraform-bridge/pf v0.15.2
-	github.com/pulumi/pulumi-terraform-bridge/v3 v3.57.0
+	github.com/pulumi/pulumi-terraform-bridge/v3 v3.58.0
 	github.com/pulumi/pulumi/sdk/v3 v3.76.1
 )
 

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -2344,8 +2344,8 @@ github.com/pulumi/pulumi-terraform-bridge/pf v0.15.2 h1:zKAzAHk9AKk+EF9FG4vT9u3j
 github.com/pulumi/pulumi-terraform-bridge/pf v0.15.2/go.mod h1:XdOy385fEso7q3NuL+zAS3I1i+X47Bg01AlVD5aJRS4=
 github.com/pulumi/pulumi-terraform-bridge/testing v0.0.1 h1:SCg1gjfY9N4yn8U8peIUYATifjoDABkyR7H9lmefsfc=
 github.com/pulumi/pulumi-terraform-bridge/testing v0.0.1/go.mod h1:7OeUPH8rpt5ipyj9EFcnXpuzQ8SHL0dyqdfa8nOacdk=
-github.com/pulumi/pulumi-terraform-bridge/v3 v3.57.0 h1:munOxi56glme47MT8/wI29o9wrRBJrEQuwjAgm1zviI=
-github.com/pulumi/pulumi-terraform-bridge/v3 v3.57.0/go.mod h1:ykaml8e6XS/yI9JOcNZ+6gLirs6EWTB0FmjbT+JyEdU=
+github.com/pulumi/pulumi-terraform-bridge/v3 v3.58.0 h1:1vQokJDOEQQuPAsvIHoqb0x7yGflfmXYcjkHrT5tkXg=
+github.com/pulumi/pulumi-terraform-bridge/v3 v3.58.0/go.mod h1:ykaml8e6XS/yI9JOcNZ+6gLirs6EWTB0FmjbT+JyEdU=
 github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.4 h1:rIzMmtcVpPX8ynaz6/nW5AHNY63DiNfCohqmxWvMpM4=
 github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.4/go.mod h1:Kt8RIZWa/N8rW3+0g6NrqCBmF3o+HuIhFaZpssEkG6w=
 github.com/pulumi/pulumi-yaml v1.1.1 h1:8pyBNIU8+ym0wYpjhsCqN+cutygfK1XbhY2YEeNfyXY=


### PR DESCRIPTION
This PR was generated via `$ upgrade-provider pulumi/pulumi-linode --kind=all`.

---

- Upgrading terraform-provider-linode from 2.7.0  to 2.7.1.
	Fixes #347
	Fixes #345
- Upgrading pulumi-terraform-bridge from v3.57.0 to v3.58.0.
